### PR TITLE
Update config.go

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,11 +37,11 @@ func LoadEnv() {
 // ReadConfigFile should initialize once jsonConfig
 func ReadConfigFile() {
 	// logger should stop execution if there is no file found
-	e, err := ioutil.ReadFile("config/" + os.Getenv("CONFIG_FILE"))
+	e, err := ioutil.ReadFile(os.Getenv("CONFIG_FILE"))
 	logger.Error(err, "Config file not found")
 
 	err = json.Unmarshal(e, &jsonConfig)
-	logger.Fatal(err, "Unable to parse config.json")
+	logger.Fatal(err, "Unable to parse " + os.Getenv("CONFIG_FILE"))
 
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -68,13 +68,12 @@ func isValidHeader(r *http.Response) bool {
 
 func modifyResponse(r *http.Response) error {
 	if !isValidHeader(r) {
-		err := errors.New("Unexpected Content-Type")
-		logger.Error(err)
-		return err
+		return nil
 	}
+
 	html, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		logger.Error(err, "Body was not provided")
+		logger.Error(err, "Malformed HTML in Content Body")
 		return err
 	}
 


### PR DESCRIPTION
- `CONFIG_FILE` should contain the relative or absolute for the configuration file.
- Proxy back responses with `content-type` different of HTML without throw any error.